### PR TITLE
Fix issue with monthly preview not showing all events

### DIFF
--- a/code/Calendar.php
+++ b/code/Calendar.php
@@ -663,6 +663,10 @@ class Calendar_Controller extends Page_Controller {
 
 	public function monthjson(SS_HTTPRequest $r) {
 		if(!$r->param('ID')) return false;
+        
+        //Increase the per page limit to 500 as the AJAX request won't look for further pages
+        $this->EventsPerPage = 500;
+        
 		$this->startDate = sfDate::getInstance(CalendarUtil::get_date_from_string($r->param('ID')));
 		$this->endDate = sfDate::getInstance($this->startDate)->finalDayOfMonth();
 		


### PR DESCRIPTION
The monthly preview calendar works by doing an ajax request for all events in each month. This was limiting to 20 events by default, due to pagination. This meant that where there were more than 20 events in a month, days after the 20th weren't being marked as having an event.